### PR TITLE
Refactoring main.c and rf_disp.

### DIFF
--- a/rfScanner/rfScanner/main.c
+++ b/rfScanner/rfScanner/main.c
@@ -23,8 +23,10 @@
 void test_delay(uint8_t ms);
 
 //Global variables
-volatile float voltage= get_input_voltage(0);
-volatile float voltage2= get_input_voltage(1);
+volatile float voltage= 0.00;
+volatile float voltage2= 0.00;
+
+
 
 //*
 ISR(TIMER1_COMPA_vect)
@@ -77,7 +79,7 @@ int run(void) {
 		delay(100);
 		
 	#endif
-	uint8_t rf_meas_counter = 0;
+	uint16_t rf_meas_counter = 0;
 	
 	adc_init();
 	timer_init();
@@ -85,7 +87,8 @@ int run(void) {
 	test_delay(10);
 
 	initI2C();
-	initDisp();
+	screen.init();
+	//initDisp();
 	test_delay(100);
 
     while(1)
@@ -101,7 +104,9 @@ int run(void) {
 			//test_delay(1);
 		#endif
 		//*
-		unsigned char buffer[20] = "data:";
+		unsigned char start[6] = "data:";
+		screen.set(1,start);
+		
 		unsigned char measure[20] = "";
 		volatile float data = 0.1;
 		volatile float rfdata = 0.11;
@@ -123,17 +128,20 @@ int run(void) {
 			clearBuffer(strlenCustom(measure),measure);
 			unsigned char result [20] = "";
 			floatToChar(data,measure,5,2);
-			combine(buffer, measure, result);
+			combine(screen.buffer, measure, result);
 			clearBuffer(strlenCustom(measure),measure);
 			floatToChar(rfdata, measure,5,2);
-			char extend[20] = "rf:";
-			combine(result, extend, result);
-			combine(result,measure,result);
-			setRowPlace(1,0);
-			setText(1,result);
-			clearBuffer(strlenCustom(buffer),buffer);
-			SplitResult bf2=split(buffer,0);
-			combine(bf2.part1,"DATA:", buffer);
+			unsigned char extend[20] = "rf:";
+			screen.combine(result, extend, result);
+			screen.combine(result,measure,result);
+			screen.setRowPlace(1,0);
+			//setRowPlace(1,0);
+			screen.set(1,result);
+			screen.clearBuffer(strlenCustom(screen.buffer),screen.buffer);
+			//SplitResult bf2 = screen.split(screen.buffer,0);
+			SplitResult bf2=split(screen.buffer,0);
+			unsigned char temp[10] = "DATA:";
+			screen.combine(bf2.part1,temp, screen.buffer);
 			test_delay(100);
 		}
 		//*/

--- a/rfScanner/rfScanner/rf_disp.h
+++ b/rfScanner/rfScanner/rf_disp.h
@@ -16,9 +16,28 @@
 #define SLAVE_ADDR 0x78
 
 typedef struct {
-    char part1[20];
-    char part2[20];
+    unsigned char part1[20];
+    unsigned char part2[20];
 } SplitResult;
+
+typedef struct {
+	unsigned char row1[20];
+	unsigned char row2[20];
+	unsigned char buffer[6];
+	unsigned char part1[10];
+	unsigned char part2[10];
+    void (*set)(uint8_t row, unsigned char* text);
+    void (*init)(void);
+    void (*intToChar)(int num, unsigned char* buffer, int buffer_size);
+    void (*floatToChar)(float num, unsigned char* buffer, int buffer_size, int precision);
+    unsigned char* (*combine) (unsigned char* x, unsigned char* y, unsigned char* combined);
+    SplitResult (*split) (unsigned char* s, int number);
+    void (*setRowPlace) (uint8_t row, uint8_t step);
+    void (*clearBuffer)(uint8_t size, unsigned char* buffer);
+ } scr;
+ 
+
+
 
 void initDisp();
 void setText(uint8_t row, unsigned char*);
@@ -27,9 +46,26 @@ void floatToChar(float num, unsigned char* buffer, int buffer_size, int precisio
 void intToChar(int num, unsigned char* buffer, int buffer_size);
 void setRowStep(uint8_t row, uint8_t step);
 void clearBuffer(uint8_t size, unsigned char*);
-char* combine(char*, char*, char*);
-int strlenCustom(char*);
-SplitResult split(char* s, int number);
+unsigned char* combine(unsigned char*, unsigned char*, unsigned char*);
+int strlenCustom(unsigned char*);
+SplitResult split(unsigned char* s, int number);
+
+
+scr screen = {
+    "",
+    "",
+    "",
+    "",
+    "",
+    setText,
+    initDisp,
+    intToChar,
+    floatToChar,
+    combine,
+    split,
+    setRowPlace,
+    clearBuffer
+};
 
 void initDisp() {
   uint16_t response;
@@ -68,7 +104,11 @@ void setText(uint8_t row, unsigned char *chars) {
   //uint16_t response;
   //response = write_command(0);
   //setRow(row);
-  write_data(chars, sizeof(chars), row);
+  for(int i = 0; i< 19; i++) {
+    screen.row1[i] = (chars[i] != '\0') ? chars[i]:' ';
+  }
+  screen.row1[19] = '\0';
+  write_data(chars, 19, row);
 	
 }
 
@@ -249,7 +289,7 @@ void clearBuffer(uint8_t size, unsigned char* buffer) {
 }
 
 
-char* combine(char* x, char* y, char* combined)
+unsigned char* combine(unsigned char* x, unsigned char* y, unsigned char* combined)
 {
     int length_x = strlenCustom(x);
     int length_y = strlenCustom(y);
@@ -280,7 +320,7 @@ char* combine(char* x, char* y, char* combined)
     return combined;
 }
 
-int strlenCustom(char* z) {
+int strlenCustom(unsigned char* z) {
     int length = 0;
     while (z[length] != '\0') {
         length++;
@@ -288,7 +328,7 @@ int strlenCustom(char* z) {
     return length;
 }
 
-SplitResult split(char* s, int number) {
+SplitResult split(unsigned char* s, int number) {
     SplitResult result;
 
 
@@ -322,4 +362,8 @@ SplitResult split(char* s, int number) {
 
     return result;
 }
+
+
+
+
 #endif


### PR DESCRIPTION
Muutettu rf_disp toimintaa ja luotu rakenne typedef menetelmällä.
 - funktioiden kutsut liitetty typedef:n alle, jolloin funktioita voidaan kutsua suoraan screen.split() tavalla.
 - tarkoituksena myös yhdistää funktioiden käyttämät muuttujat siten, että voidaan käyttää yhtä typedef metodia.

Voi todennäköisesti vähentää tällä menetelmällä funktioiden sisältöä siten, ettei tarvitse niin monta muuttujaa toimittaa funktioille.
